### PR TITLE
update Racket to latest (8.2) but leave the old backend (BC)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           architecture: 'x64'
           distribution: 'full'
-          variant: 'BS' # an FFI blog post requirement
+          variant: 'BC' # an FFI blog post requirement
           version: '8.2'
           packages: 'gregor,frog,honu'
       #- name: Setup upterm session

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           architecture: 'x64'
           distribution: 'full'
-          variant: 'BC' # an FFI blog post requirement
+          variant: 'BS' # an FFI blog post requirement
           version: '8.2'
           packages: 'gregor,frog,honu'
       #- name: Setup upterm session

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Racket
-        uses: Bogdanp/setup-racket@v0.8
+        uses: Bogdanp/setup-racket@v1.6.1
         with:
           architecture: 'x64'
           distribution: 'full'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,19 +11,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Cache Racket dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/racket
-            ~/.local/share/racket
-          key: default
       - name: Install Racket
         uses: Bogdanp/setup-racket@v0.8
         with:
           architecture: 'x64'
           distribution: 'full'
-          version: '7.9'
+          variant: 'BC' # an FFI blog post requirement
+          version: '8.2'
           packages: 'gregor,frog,honu'
       #- name: Setup upterm session
       #  uses: lhotari/action-upterm@v1


### PR DESCRIPTION
This is required for one of the FFI blog posts.